### PR TITLE
fix: usar média de consumo da viagem atual no widget HEV

### DIFF
--- a/app/src/main/java/br/com/redesurftank/havalshisuku/projectors/InstrumentProjector2.kt
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/projectors/InstrumentProjector2.kt
@@ -202,7 +202,7 @@ class InstrumentProjector2(outerContext: Context, display: Display) : BaseProjec
                         evaluateJsIfReady(webView, "control('batteryLevel', $value)")
                     }
 
-                    CarConstants.CAR_BASIC_AVG_FUEL_CONSUMPTION.value -> {
+                    CarConstants.CAR_BASIC_CUR_JOURNEY_AVG_FUEL_CONSUME.value -> {
                         evaluateJsIfReady(webView, "control('avgGasConsumption', $value)")
                     }
 
@@ -337,7 +337,7 @@ class InstrumentProjector2(outerContext: Context, display: Display) : BaseProjec
         val outsideTemp = ServiceManager.getInstance().getData(CarConstants.CAR_BASIC_OUTSIDE_TEMP.value).toFloat().roundToInt()
         val onePedal = ServiceManager.getInstance().getData(CarConstants.CAR_CONFIGURE_PEDAL_CONTROL_ENABLE.value) == "1"
         val batteryLevel = ServiceManager.getInstance().getData(CarConstants.CAR_EV_INFO_CUR_BATTERY_POWER_PERCENTAGE.value)
-        val avgGas = ServiceManager.getInstance().getData(CarConstants.CAR_BASIC_AVG_FUEL_CONSUMPTION.value)
+        val avgGas = ServiceManager.getInstance().getData(CarConstants.CAR_BASIC_CUR_JOURNEY_AVG_FUEL_CONSUME.value)
         val avgEv = ServiceManager.getInstance().getData(CarConstants.CAR_EV_INFO_AVG_ENERGY_CONSUME_INFO_SINCE_STARTUP.value)
         val instantEv = ServiceManager.getInstance().getData(CarConstants.CAR_EV_INFO_INSTANT_ENERGY_CONSUMPTION.value)
 

--- a/app/src/main/java/br/com/redesurftank/havalshisuku/projectors/InstrumentProjector2.kt
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/projectors/InstrumentProjector2.kt
@@ -206,11 +206,11 @@ class InstrumentProjector2(outerContext: Context, display: Display) : BaseProjec
                         evaluateJsIfReady(webView, "control('avgGasConsumption', $value)")
                     }
 
-                    CarConstants.CAR_EV_INFO_AVG_ENERGY_CONSUME_INFO_SINCE_STARTUP.value -> {
+                    CarConstants.CAR_EV_INFO_CYCLE_ENERGY_CONSUME_INFO.value -> {
                         evaluateJsIfReady(webView, "control('avgEvConsumption', $value)")
                     }
 
-                    CarConstants.CAR_EV_INFO_INSTANT_ENERGY_CONSUMPTION.value -> {
+                    CarConstants.CAR_EV_INFO_ENERGY_CONSUME_INFO.value -> {
                         evaluateJsIfReady(webView, "control('instantEvConsumption', $value)")
                     }
 
@@ -338,8 +338,8 @@ class InstrumentProjector2(outerContext: Context, display: Display) : BaseProjec
         val onePedal = ServiceManager.getInstance().getData(CarConstants.CAR_CONFIGURE_PEDAL_CONTROL_ENABLE.value) == "1"
         val batteryLevel = ServiceManager.getInstance().getData(CarConstants.CAR_EV_INFO_CUR_BATTERY_POWER_PERCENTAGE.value)
         val avgGas = ServiceManager.getInstance().getData(CarConstants.CAR_BASIC_CUR_JOURNEY_AVG_FUEL_CONSUME.value)
-        val avgEv = ServiceManager.getInstance().getData(CarConstants.CAR_EV_INFO_AVG_ENERGY_CONSUME_INFO_SINCE_STARTUP.value)
-        val instantEv = ServiceManager.getInstance().getData(CarConstants.CAR_EV_INFO_INSTANT_ENERGY_CONSUMPTION.value)
+        val avgEv = ServiceManager.getInstance().getData(CarConstants.CAR_EV_INFO_CYCLE_ENERGY_CONSUME_INFO.value)
+        val instantEv = ServiceManager.getInstance().getData(CarConstants.CAR_EV_INFO_ENERGY_CONSUME_INFO.value)
 
         evaluateJsIfReady(webView, "control('temp', $currentTemp)")
         evaluateJsIfReady(webView, "control('fan', $currentFanSpeed)")


### PR DESCRIPTION
Alterado de CAR_BASIC_AVG_FUEL_CONSUMPTION (média histórica) para
CAR_BASIC_CUR_JOURNEY_AVG_FUEL_CONSUME (média da viagem atual) para
que o widget mostre o mesmo valor da tela "desde o início" do veículo.