### PR TITLE
fix: atualizar repositório do auto-update para rafaeldl

### DIFF
--- a/app/src/main/java/br/com/redesurftank/havalshisuku/MainActivity.kt
+++ b/app/src/main/java/br/com/redesurftank/havalshisuku/MainActivity.kt
@@ -1966,9 +1966,9 @@ fun InformacoesTab() {
         return withContext(Dispatchers.IO) {
             try {
                 val endpoint = if (isPreview)
-                    "https://api.github.com/repos/bobaoapae/haval-app-tool-multimidia/releases"
+                    "https://api.github.com/repos/rafaeldl/haval-app-tool-multimidia/releases"
                 else
-                    "https://api.github.com/repos/bobaoapae/haval-app-tool-multimidia/releases/latest"
+                    "https://api.github.com/repos/rafaeldl/haval-app-tool-multimidia/releases/latest"
 
                 val url = URL(endpoint)
                 val conn = url.openConnection() as HttpURLConnection


### PR DESCRIPTION
Alterado o endpoint do GitHub API para buscar atualizações do repositório rafaeldl/haval-app-tool-multimidia ao invés de bobaoapae/haval-app-tool-multimidia